### PR TITLE
added support for :item_attributes for Representative::Json

### DIFF
--- a/lib/representative/json.rb
+++ b/lib/representative/json.rb
@@ -44,17 +44,23 @@ module Representative
     end
     
     def list_of(name, *args, &block)
+      options = args.extract_options!
       list_subject = args.empty? ? name : args.shift
+      raise ArgumentError, "too many arguments" unless args.empty?
+      list_attributes = options[:list_attributes]
+      raise ArgumentError, "list_attributes #{list_attributes} not supported for json representation" if list_attributes
+      item_attributes = options[:item_attributes] || {}
+
       items = resolve_value(list_subject)
       label(name)
       inside "[", "]" do
         items.each do |item|
           new_item
-          value(item, &block)
+          value(item, item_attributes, &block)
         end
       end
     end
-
+    
     def value(subject, attributes = {})
       representing(subject) do
         if block_given? && !current_subject.nil?

--- a/spec/representative/json_spec.rb
+++ b/spec/representative/json_spec.rb
@@ -178,6 +178,46 @@ describe Representative::Json do
         end
         
       end
+      
+      describe "with item attributes" do
+        it "adds the attributes with an @ sign to child elements" do
+          @authors = [
+            OpenStruct.new(:name => "Hewey", :age => 3),
+            OpenStruct.new(:name => "Dewey", :age => 4),
+            OpenStruct.new(:name => "Louie", :age => 5)
+          ]
+          r.list_of :authors, @authors, :item_attributes => {:about => lambda{|obj| "#{obj.name} is #{obj.age} years old"}} do
+            r.element :name
+            r.element :age
+          end
+          resulting_json.should == undent(<<-JSON)
+          [
+            {
+              "@about": "Hewey is 3 years old",
+              "name": "Hewey",
+              "age": 3
+            },
+            {
+              "@about": "Dewey is 4 years old",              
+              "name": "Dewey",
+              "age": 4
+            },
+            {
+              "@about": "Louie is 5 years old",
+              "name": "Louie",
+              "age": 5
+            }
+          ]
+          JSON
+        end
+      end
+      
+      describe "with list attributes" do
+        it "raises an ArgumentError" do
+          @authors = []
+          lambda{ r.list_of(:authors, @authors, :list_attributes => {}) {} }.should raise_exception(ArgumentError)
+        end
+      end
 
     end
 


### PR DESCRIPTION
Hey Mike

Jon and I were making some Atlas tweaks to render JSON alongside the XML via the internal API. Spotted a missing feature in Representative where attributes specified on the representation (that were included at element attributes in the XML), were not rendered at all for elements in JSON lists - they were fine for JSON single elements though.

Small patch to add support for this included.

Cheers
Julian
