### PR TITLE
Allow use of own choice in JSON encoder

### DIFF
--- a/lib/representative/json.rb
+++ b/lib/representative/json.rb
@@ -15,6 +15,7 @@ module Representative
       @indent_level = 0
       @indent_string = resolve_indentation(options.fetch(:indentation, DEFAULT_INDENTATION))
       @attribute_prefix = options.fetch(:attribute_prefix, DEFAULT_ATTRIBUTE_PREFIX)
+      @encoder = options.fetch(:encoder, ActiveSupport::JSON)
       now_at :beginning_of_buffer
       yield self if block_given?
     end
@@ -112,7 +113,7 @@ module Representative
     end
 
     def encode(data)
-      ActiveSupport::JSON.encode(data)
+      @encoder.encode(data)
     end
 
     def indenting?

--- a/lib/representative/json.rb
+++ b/lib/representative/json.rb
@@ -1,10 +1,16 @@
-require "activesupport/json_encoder"
 require "active_support/core_ext/array/extract_options"
 require "representative/base"
+require "json"
 
 module Representative
 
   class Json < Base
+
+    class DefaultEncoder
+      def self.encode(data)
+        ::JSON.dump(data)
+      end
+    end
 
     DEFAULT_ATTRIBUTE_PREFIX = "@".freeze
     DEFAULT_INDENTATION = 2 # two spaces
@@ -15,7 +21,7 @@ module Representative
       @indent_level = 0
       @indent_string = resolve_indentation(options.fetch(:indentation, DEFAULT_INDENTATION))
       @attribute_prefix = options.fetch(:attribute_prefix, DEFAULT_ATTRIBUTE_PREFIX)
-      @encoder = options.fetch(:encoder, ActiveSupport::JSON)
+      @encoder = options.fetch(:encoder, DefaultEncoder)
       now_at :beginning_of_buffer
       yield self if block_given?
     end

--- a/representative.gemspec
+++ b/representative.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.platform = Gem::Platform::RUBY
 
   gem.add_development_dependency("rspec", "~> 3.4.0")
-  gem.add_runtime_dependency("activesupport-json_encoder", ">= 1.1.0")
+  gem.add_runtime_dependency("activesupport", ">= 3.0")
   gem.add_runtime_dependency("i18n", ">= 0.4.1")
   gem.add_runtime_dependency("builder", ">= 2.1.2")
   gem.add_runtime_dependency("nokogiri", ">= 1.4.2")

--- a/spec/representative/json_spec.rb
+++ b/spec/representative/json_spec.rb
@@ -423,4 +423,29 @@ describe Representative::Json do
 
   end
 
+  context "with encoder option" do
+
+    class FakeEncoder
+      def self.encode(data)
+        (data.to_s + "!!!").inspect
+      end
+    end
+
+    before do
+      @authors = [
+        OpenStruct.new(:name => "Hewey", :age => 3),
+        OpenStruct.new(:name => "Dewey", :age => 4)
+      ]
+    end
+
+    it "uses the encoder provided" do
+      r(:indentation => false, :encoder => FakeEncoder).list_of :authors, @authors do
+        r.element :name
+        r.element :age
+      end
+
+      expect(resulting_json).to eq %([{"name":"Hewey!!!","age":"3!!!"},{"name":"Dewey!!!","age":"4!!!"}])
+    end
+  end
+
 end


### PR DESCRIPTION
ActiveSupport::JSON can be slow so i'd like to be able to choose which JSON encoder I use. Replaced ActiveSupport::JSON with base JSON dump as it seems to be fufilling the same purposes, removing the dependency on activesupport json encoder.
