### PR TITLE
Compatibility with Rails 5+

### DIFF
--- a/lib/representative/json.rb
+++ b/lib/representative/json.rb
@@ -1,4 +1,4 @@
-require "activesupport/json_encoder"
+require "active_support/json"
 require "active_support/core_ext/array/extract_options"
 require "representative/base"
 

--- a/lib/representative/version.rb
+++ b/lib/representative/version.rb
@@ -1,3 +1,3 @@
 module Representative
-  VERSION = "1.2.0".freeze
+  VERSION = "2.0.0".freeze
 end

--- a/representative.gemspec
+++ b/representative.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.platform = Gem::Platform::RUBY
 
   gem.add_development_dependency("rspec", "~> 3.4.0")
-  gem.add_runtime_dependency("activesupport-json_encoder", ">= 1.1.0")
+  gem.add_runtime_dependency("activesupport", "~> 5.1")
   gem.add_runtime_dependency("i18n", ">= 0.4.1")
   gem.add_runtime_dependency("builder", ">= 2.1.2")
   gem.add_runtime_dependency("nokogiri", ">= 1.4.2")


### PR DESCRIPTION
The dependency on `activesupport-json_encoder` prevents the possibility to use `representative` on Rails 5+.

Requiring `active_support/json` fixes the issue.